### PR TITLE
 Changing log options to enum 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ _logReport.Log("your test name / context name");
 If you are not looking fo all logs, just a screenshoot or browser console info, you can filter them after the `Setup` method, calling from the SReportBuilder. As Example:
 
 ```csharp
+// AddLog method cascate
 SReport _logReport = SReportBuilder.Setup(yourIWebDriver, desiredLogFolder)
-                .WithConsoleLogs()
-                .WithGeneralInfo()
-                .WithPageStateHtml()
-                .WithScreenshoot()
+                .AddLog(SLog.Screenshoot)
+                .AddLog(SLog.BrowserConsole)
+                .AddLog(SLog.PageHtml)
+                .Build();
+				
+// Only one AddLog call
+SReport _logReport = SReportBuilder.Setup(yourIWebDriver, desiredLogFolder)
+                .AddLog(SLog.Screenshoot, SLog.BrowserConsole, SLog.PageHtml)
                 .Build();
 ```
 
@@ -39,20 +44,17 @@ Take a Screenshoot based in the Browser View, and saves it as .png file.
 * **Browser Console**: 
 Saves a text file containing browser console content.
 
-* **General Info**:
-Saves a text file containing the test name, generation date, OS and framework version.
-
-* **Page State Html**:
+* **Page Html**:
 Create a .htm file with the real state of the page. It can be also manipulated in a browser DevTools to be easy to correct errors based on element queries.
 
 * **WebDriver Instance**:
-Log Based on Selenium Web Driver Messages log type.
+Log Based on Selenium Web Driver Instance report.
 
 * **Selenium Client**:
-Log Based on Selenium Server log type. 
-
-* **Selenium Client**:
-Log Based on Selenium Client log type. 
+Log Based on Selenium Server report. 
 
 * **Profiling**:
-Log Based on Selenium Profile log type. 
+Log Based on Selenium Profile report. 
+
+* **Profiling**:
+Log Based on Selenium Server Messages report. 

--- a/SReport/SLog.cs
+++ b/SReport/SLog.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace SReport
+{
+    [Flags]
+    public enum SLog
+    {
+        Screenshoot        = 0b0000001,
+        BrowserConsole     = 0b0000010,
+        PageHtml           = 0b0000100,
+        SeleniumClient     = 0b0001000,
+        WebDriverInstance  = 0b0010000,
+        Profiling          = 0b0100000,
+        ServerMessages     = 0b1000000
+    }
+}

--- a/SReport/SReport.cs
+++ b/SReport/SReport.cs
@@ -2,23 +2,16 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 
-namespace SReportLog
+namespace SReport
 {
     public class SReport
     {
         private readonly IWebDriver _driver;
 
+        internal SLog sLogs;
+
         public readonly string LogsPath;
-        public bool Screenshoot{get; internal set;}
-        public bool BrowserConsole { get; internal set; }
-        public bool GeneralInfo { get; internal set; }
-        public bool PageStateHtml { get; internal set; }
-        public bool SeleniumClient { get; internal set; }
-        public bool WebDriverInstance { get; internal set; }
-        public bool Profiling { get; internal set; }
-        public bool ServerMessages { get; internal set; }
 
         internal SReport(IWebDriver driver, string logsPath)
         {
@@ -44,56 +37,45 @@ namespace SReportLog
                 foreach (var file in files)
                     file.Delete();
             }
-
-            if (GeneralInfo)
-            {
-                using (var stream = File.CreateText(Path.Combine(tesLogFolder, $"{nameof(GeneralInfo)}.txt")))
-                {
-                    stream.WriteLine($"Date: {DateTime.Now.ToLongDateString()} - {DateTime.Now.ToLongTimeString()}");
-                    stream.WriteLine($"Test name: {testName} {Environment.NewLine}");
-                    stream.WriteLine($"{RuntimeInformation.OSDescription}");
-                    stream.WriteLine($"{RuntimeInformation.FrameworkDescription}");
-                }
-            }
-
-            if (Screenshoot)
+            
+            if (sLogs.HasFlag(SLog.Screenshoot))
             {
                 var screenshot = (_driver as ITakesScreenshot).GetScreenshot();
-                screenshot.SaveAsFile(Path.Combine(tesLogFolder, $"{nameof(Screenshoot)}.png"), ScreenshotImageFormat.Png);
+                screenshot.SaveAsFile(Path.Combine(tesLogFolder, $"{nameof(SLog.Screenshoot)}.png"), ScreenshotImageFormat.Png);
             }
 
-            if (BrowserConsole)
+            if (sLogs.HasFlag(SLog.BrowserConsole))
             {
                 SeleniumLog(tesLogFolder, LogType.Browser);
             }
 
-            if (SeleniumClient)
+            if (sLogs.HasFlag(SLog.SeleniumClient))
             {
                 SeleniumLog(tesLogFolder, LogType.Client);
             }
 
-            if (WebDriverInstance)
+            if (sLogs.HasFlag(SLog.WebDriverInstance))
             {
                 SeleniumLog(tesLogFolder, LogType.Driver);
             }
 
-            if (Profiling)
+            if (sLogs.HasFlag(SLog.Profiling))
             {
                 SeleniumLog(tesLogFolder, LogType.Profiler);
             }
 
-            if (ServerMessages)
+            if (sLogs.HasFlag(SLog.ServerMessages))
             {
                 SeleniumLog(tesLogFolder, LogType.Server);
             }
 
-            if (PageStateHtml)
+            if (sLogs.HasFlag(SLog.PageHtml))
             {
                 var styles = _driver.FindElements(By.TagName("link"))
                     .Where(x => !string.IsNullOrWhiteSpace(x.GetAttribute("href")) && x.GetAttribute("rel").ToLower() == "stylesheet")
                     .Select(x => x.GetAttribute("href"));
 
-                using (var stream = File.CreateText(Path.Combine(tesLogFolder, $"{nameof(PageStateHtml)}.htm")))
+                using (var stream = File.CreateText(Path.Combine(tesLogFolder, $"{nameof(SLog.PageHtml)}.htm")))
                 {
                     stream.WriteLine(_driver.PageSource);
                     foreach(var style in styles)

--- a/SReport/SReportBuilder.cs
+++ b/SReport/SReportBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using OpenQA.Selenium;
+using System;
+using System.Linq;
 
-namespace SReportLog
+namespace SReport
 {
     public class SReportBuilder
     {
@@ -12,66 +14,18 @@ namespace SReportLog
         public static SReportBuilder Setup(IWebDriver driver, string logsPath) => 
             new SReportBuilder(driver, logsPath);
 
-        public SReportBuilder WithScreenshoot()
+        public SReportBuilder AddLog(params SLog[] logs)
         {
-            sReport.Screenshoot = true;
+            foreach(var log in logs)
+            {
+                sReport.sLogs |= log;
+            }
+
             return this;
         }
 
-        public SReportBuilder WithConsoleLogs()
-        {
-            sReport.BrowserConsole = true;
-            return this;
-        }
-
-        public SReportBuilder WithProfilingLogs()
-        {
-            sReport.Profiling = true;
-            return this;
-        }
-
-        public SReportBuilder WithServerMessagesLogs()
-        {
-            sReport.ServerMessages = true;
-            return this;
-        }
-
-        public SReportBuilder WithSeleniumClientLogs()
-        {
-            sReport.SeleniumClient = true;
-            return this;
-        }
-
-        public SReportBuilder WithWebDriverInstanceLogs()
-        {
-            sReport.WebDriverInstance = true;
-            return this;
-        }
-
-        public SReportBuilder WithPageStateHtmlLogs()
-        {
-            sReport.PageStateHtml = true;
-            return this;
-        }
-
-        public SReportBuilder WithGeneralInfoLogs()
-        {
-            sReport.GeneralInfo = true;
-            return this;
-        }
-
-        public SReportBuilder WithAllLogsEnabled()
-        {
-            sReport.BrowserConsole = true;
-            sReport.GeneralInfo = true;
-            sReport.PageStateHtml = true;
-            sReport.Profiling = true;
-            sReport.Screenshoot = true;
-            sReport.SeleniumClient = true;
-            sReport.ServerMessages = true;
-            sReport.WebDriverInstance = true;
-            return this;
-        }
+        public SReportBuilder AddAllLogs() =>
+            AddLog(Enum.GetValues(typeof(SLog)).Cast<SLog>().ToArray());
 
         public SReport Build() => 
             sReport;


### PR DESCRIPTION
It changes the code to be smaller and easier to be mainaner.
Also, does not need maintenance on builder when add a new log.